### PR TITLE
src/build_macos.sh: Fixes for universal macOS builds.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyQt5>=5.0
 PyQt5-Qt5>=5.0
 pyserial>=3.0
+PyInstaller>=5.0

--- a/src/build_macos.sh
+++ b/src/build_macos.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-python3 -m PyInstaller --noconfirm --windowed --name="upide" --icon=upide.icns --add-data='assets:assets' upide.py
+# requires create-dmg (brew install create-dmg)
+python3 -m PyInstaller --target-arch=universal2 --noconfirm --windowed --name="upide" --icon=upide.icns --add-data='assets:assets' upide.py
 mkdir -p dist/dmg
 rm -r dist/dmg/*
 cp -r dist/upide.app dist/dmg


### PR DESCRIPTION
Added a universal flag to the PyInstaller command, and added PyInstaller to `requirements.txt`

Also added a comment noting the need to install the create-dmg command which is not standard on macOS. This could be improved i.e. script could check for it and output a prettier / more useful error if the developer has not read the script 😄 

Finally, note that in order for universal builds to work, it needs a universal build of Python on the build machine - Homebrew installed Python are single architecture (so on my machine, this reports a warning about the lack of universal Python, and builds me an Apple Silicon version, which is fine, but not suitable for general distribution where you would want a universal build).

TODO: add some documentation about how to run builds for each OS, this was done without instructions 😉 

Fixes #12 